### PR TITLE
Get removefiles RemoveNames from config

### DIFF
--- a/removefiles/activity.go
+++ b/removefiles/activity.go
@@ -14,17 +14,21 @@ import (
 
 const ActivityName = "remove-files-activity"
 
-type Activity struct{}
+type Config struct {
+	// RemoveNames is the comma separated list of filenames that should be
+	// removed from all transfers.
+	RemoveNames string
+}
 
-func NewActivity() *Activity {
-	return &Activity{}
+type Activity struct {
+	cfg Config
+}
+
+func NewActivity(cfg Config) *Activity {
+	return &Activity{cfg: cfg}
 }
 
 type ActivityParams struct {
-	// RemoveNames is the comma separated list of filenames that should be
-	// removed from Path.
-	RemoveNames string
-
 	// Path is the directory from which files should be removed.
 	Path string
 }
@@ -48,12 +52,13 @@ type ActivityResult struct {
 // anything.
 func (a *Activity) Execute(ctx context.Context, params *ActivityParams) (*ActivityResult, error) {
 	logger := temporal.GetLogger(ctx)
-	logger.V(2).Info("Executing RemoveFilesActivity",
-		"RemoveNames", params.RemoveNames,
+	logger.V(1).Info(
+		"Executing RemoveFilesActivity",
+		"RemoveNames", a.cfg.RemoveNames,
 		"Path", params.Path,
 	)
 
-	count, err := removeByNames(params.Path, params.RemoveNames)
+	count, err := removeByNames(params.Path, a.cfg.RemoveNames)
 	if err != nil {
 		return nil, fmt.Errorf("RemoveFilesActivity: %v", err)
 	}


### PR DESCRIPTION
To make the remove files activity more compatible with the Enduro preprocessing config system, get the list of RemoveNames from a `cfg` property instead of a parameter of the Execute() method.