### PR TITLE
Add an activity to create a BagIt bag (refs #11)

### DIFF
--- a/bagit/config.go
+++ b/bagit/config.go
@@ -1,0 +1,35 @@
+package bagit
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+)
+
+var hashingAlgorithms = []string{"md5", "sha1", "sha256", "sha512"}
+
+type Config struct {
+	// ChecksumAlgorithm specifies the hashing algorithm used to generate file
+	// checksums. Valid values are "md5", "sha1", "sha256", "sha512" (default)
+	ChecksumAlgorithm string
+}
+
+func (c *Config) setDefaults() {
+	if c.ChecksumAlgorithm == "" {
+		c.ChecksumAlgorithm = "sha512"
+	}
+}
+
+func (c *Config) Validate() error {
+	c.setDefaults()
+
+	if !slices.Contains(hashingAlgorithms, c.ChecksumAlgorithm) {
+		return fmt.Errorf(
+			"ChecksumAlgorithm: invalid value %q, must be one of (%s)",
+			c.ChecksumAlgorithm,
+			strings.Join(hashingAlgorithms, ", "),
+		)
+	}
+
+	return nil
+}

--- a/bagit/config_test.go
+++ b/bagit/config_test.go
@@ -1,0 +1,43 @@
+package bagit_test
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/artefactual-sdps/temporal-activities/bagit"
+)
+
+func TestValidate(t *testing.T) {
+	t.Parallel()
+
+	type test struct {
+		name    string
+		cfg     bagit.Config
+		wantErr string
+	}
+
+	for _, tt := range []test{
+		{
+			name: "No errors on valid config",
+			cfg:  bagit.Config{ChecksumAlgorithm: "md5"},
+		},
+		{
+			name:    "Errors on invalid ChecksumAlgorithm",
+			cfg:     bagit.Config{ChecksumAlgorithm: "foo"},
+			wantErr: "ChecksumAlgorithm: invalid value \"foo\", must be one of (md5, sha1, sha256, sha512)",
+		},
+	} {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := tt.cfg.Validate()
+			if tt.wantErr != "" {
+				assert.Error(t, err, tt.wantErr)
+				return
+			}
+			assert.NilError(t, err)
+		})
+	}
+}

--- a/bagit/create_bag_activity.go
+++ b/bagit/create_bag_activity.go
@@ -1,0 +1,90 @@
+package bagit
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+
+	gobagit "github.com/nyudlts/go-bagit"
+	cp "github.com/otiai10/copy"
+	"go.artefactual.dev/tools/fsutil"
+	"go.artefactual.dev/tools/temporal"
+)
+
+const (
+	CreateBagActivityName = "create-bag-activity"
+
+	dirMode  fs.FileMode = 0o700
+	fileMode fs.FileMode = 0o600
+)
+
+type CreateBagActivity struct {
+	cfg *Config
+}
+
+func NewCreateBagActivity(cfg Config) *CreateBagActivity {
+	cfg.setDefaults()
+
+	return &CreateBagActivity{cfg: &cfg}
+}
+
+type CreateBagActivityParams struct {
+	// SourcePath is the path of the files to be added to the created Bag.
+	SourcePath string
+
+	// BagPath is the path where the Bag should be created. If BagPath is empty,
+	// then the Bag will be created at SourcePath, replacing the original
+	// directory contents.
+	BagPath string
+}
+
+type CreateBagActivityResult struct {
+	// BagPath of the path to the created Bag.
+	BagPath string
+}
+
+// Execute creates a BagIt Bag containing the files at SourcePath.
+//
+// If BagPath is set in the parameters, then the Bag will be created at BagPath.
+// If BagPath is empty, then the Bag will be created at SourcePath, replacing
+// the original directory contents. In either case the path of the Bag is
+// returned.
+func (a *CreateBagActivity) Execute(
+	ctx context.Context,
+	params *CreateBagActivityParams,
+) (*CreateBagActivityResult, error) {
+	logger := temporal.GetLogger(ctx)
+	logger.V(1).Info("Executing CreateBagActivity", "SourcePath", params.SourcePath)
+
+	dest, err := a.create(params.SourcePath, params.BagPath)
+	if err != nil {
+		return nil, fmt.Errorf("CreateBagActivity: %v", err)
+	}
+
+	return &CreateBagActivityResult{BagPath: dest}, nil
+}
+
+// create creates a BagIt Bag at dest from the files at src. If dest is empty,
+// the BagIt Bag is created in-place at src.
+func (a *CreateBagActivity) create(src, dest string) (string, error) {
+	if dest == "" {
+		dest = src
+	} else {
+		if err := cp.Copy(src, dest); err != nil {
+			return "", fmt.Errorf("copy source dir to bag path: %v", err)
+		}
+	}
+
+	// CreateBag currently only runs a single process to create a bag. If this
+	// changes in the future we should add a config value to set numProcesses.
+	_, err := gobagit.CreateBag(dest, a.cfg.ChecksumAlgorithm, 1)
+	if err != nil {
+		return "", fmt.Errorf("create bag: %v", err)
+	}
+
+	if err := fsutil.SetFileModes(dest, dirMode, fileMode); err != nil {
+		return "", fmt.Errorf("set file modes: %v", err)
+	}
+
+	return dest, nil
+}

--- a/bagit/create_bag_activity_test.go
+++ b/bagit/create_bag_activity_test.go
@@ -1,0 +1,138 @@
+package bagit_test
+
+import (
+	"io/fs"
+	"testing"
+
+	temporalsdk_activity "go.temporal.io/sdk/activity"
+	temporalsdk_testsuite "go.temporal.io/sdk/testsuite"
+	"gotest.tools/v3/assert"
+	tfs "gotest.tools/v3/fs"
+
+	"github.com/artefactual-sdps/temporal-activities/bagit"
+)
+
+const (
+	dirMode  fs.FileMode = 0o700
+	fileMode fs.FileMode = 0o600
+
+	sha256manifest string = `5896fb5c3f2944f57c993fa06c130ff2c4182e4fea61c2597c52b0f9d437040e  data/another.txt
+4450c8a88130a3b397bfc659245c4f0f87a8c79d017a60bdb1bd32f4b51c8133  data/small.txt
+`
+	sha512manifest string = `946af3bfd3b0b84ea0d99136085dcd66ee7e769371dbcd097ed35fd377116087e25d004afd68dc48e4eb0bcb6a434b04078577b531a7da1452296d1ae98d20b3  data/another.txt
+8cbdd4ed5452f7c066509c066d5ea87fc03f30b0c67153624a1bce4d6e14b6709b5e78caf723cdf419d0efad4db96ba1cad3196783c26a7743029459bdd148b0  data/small.txt
+`
+)
+
+func defaultBagContents(t *testing.T) tfs.Manifest {
+	return tfs.Expected(t,
+		tfs.WithFile("bag-info.txt", "", tfs.MatchAnyFileContent, tfs.WithMode(fileMode)),
+		tfs.WithFile("bagit.txt", "", tfs.MatchAnyFileContent, tfs.WithMode(fileMode)),
+		tfs.WithFile("manifest-sha512.txt", sha512manifest, tfs.WithMode(fileMode)),
+		tfs.WithFile("tagmanifest-sha512.txt", "", tfs.MatchAnyFileContent, tfs.WithMode(fileMode)),
+		tfs.WithDir("data", tfs.WithMode(dirMode),
+			tfs.WithFile("small.txt", "I am a small file.\n", tfs.WithMode(fileMode)),
+			tfs.WithFile("another.txt", "I am another file.\n", tfs.WithMode(fileMode)),
+		),
+	)
+}
+
+func sourcePath(t *testing.T) string {
+	t.Helper()
+
+	td := tfs.NewDir(t, "sdps_bagit_create_test",
+		tfs.WithFile("small.txt", "I am a small file.\n"),
+		tfs.WithFile("another.txt", "I am another file.\n"),
+	)
+
+	return td.Path()
+}
+
+func TestExtractActivity(t *testing.T) {
+	t.Parallel()
+
+	type test struct {
+		name    string
+		cfg     bagit.Config
+		params  bagit.CreateBagActivityParams
+		want    tfs.Manifest
+		wantErr string
+	}
+	for _, tt := range []test{
+		{
+			name: "Creates a bag in place",
+			params: bagit.CreateBagActivityParams{
+				SourcePath: sourcePath(t),
+			},
+			want: defaultBagContents(t),
+		},
+		{
+			name: "Creates a bag in a new dir",
+			params: bagit.CreateBagActivityParams{
+				SourcePath: sourcePath(t),
+				BagPath:    tfs.NewDir(t, "sdps_bagit_create_test").Path(),
+			},
+			want: defaultBagContents(t),
+		},
+		{
+			name: "Creates a bag with SHA-256 checksums",
+			cfg:  bagit.Config{ChecksumAlgorithm: "sha256"},
+			params: bagit.CreateBagActivityParams{
+				SourcePath: sourcePath(t),
+				BagPath:    tfs.NewDir(t, "sdps_bagit_create_test").Path(),
+			},
+			want: tfs.Expected(t,
+				tfs.WithFile("bag-info.txt", "", tfs.MatchAnyFileContent, tfs.WithMode(fileMode)),
+				tfs.WithFile("bagit.txt", "", tfs.MatchAnyFileContent, tfs.WithMode(fileMode)),
+				tfs.WithFile("manifest-sha256.txt", sha256manifest, tfs.WithMode(fileMode)),
+				tfs.WithFile("tagmanifest-sha256.txt", "", tfs.MatchAnyFileContent, tfs.WithMode(fileMode)),
+				tfs.WithDir("data", tfs.WithMode(dirMode),
+					tfs.WithFile("small.txt", "I am a small file.\n", tfs.WithMode(fileMode)),
+					tfs.WithFile("another.txt", "I am another file.\n", tfs.WithMode(fileMode)),
+				),
+			),
+		},
+		{
+			name: "Errors if source dir is empty",
+			params: bagit.CreateBagActivityParams{
+				SourcePath: tfs.NewDir(t, "sdps_bagit_create_test").Path(),
+			},
+			wantErr: "activity error (type: create-bag-activity, scheduledEventID: 0, startedEventID: 0, identity: ): CreateBagActivity: create bag: could not create a bag, no files present in",
+		},
+		{
+			name: "Errors if bag path isn't writable",
+			params: bagit.CreateBagActivityParams{
+				SourcePath: sourcePath(t),
+				BagPath:    tfs.NewDir(t, "sdps_bagit_create_test", tfs.WithMode(0o600)).Path(),
+			},
+			wantErr: "activity error (type: create-bag-activity, scheduledEventID: 0, startedEventID: 0, identity: ): CreateBagActivity: copy source dir to bag path: open",
+		},
+	} {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ts := &temporalsdk_testsuite.WorkflowTestSuite{}
+			env := ts.NewTestActivityEnvironment()
+			env.RegisterActivityWithOptions(
+				bagit.NewCreateBagActivity(tt.cfg).Execute,
+				temporalsdk_activity.RegisterOptions{Name: bagit.CreateBagActivityName},
+			)
+
+			enc, err := env.ExecuteActivity(bagit.CreateBagActivityName, tt.params)
+			if tt.wantErr != "" {
+				assert.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			assert.NilError(t, err)
+
+			var result bagit.CreateBagActivityResult
+			_ = enc.Get(&result)
+
+			// The bag metadata (bag-info.txt, bagit.txt) are non-deterministic,
+			// so just assert that the expected metadata files are present, the
+			// manifest is correct, and data directory contains the right files.
+			assert.Assert(t, tfs.Equal(result.BagPath, tt.want))
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,13 @@
 module github.com/artefactual-sdps/temporal-activities
 
-go 1.21
+go 1.21.4
 
 require (
 	github.com/google/safeopen v0.0.0-20240125081138-66b54d5181c6
 	github.com/mholt/archiver/v4 v4.0.0-alpha.8
+	github.com/nyudlts/go-bagit v0.3.0-alpha.0.20240515212815-8dab411c23af
 	github.com/otiai10/copy v1.14.0
-	go.artefactual.dev/tools v0.12.0
+	go.artefactual.dev/tools v0.14.0
 	go.temporal.io/sdk v1.26.1
 	gotest.tools/v3 v3.5.1
 )

--- a/go.sum
+++ b/go.sum
@@ -128,6 +128,8 @@ github.com/mholt/archiver/v4 v4.0.0-alpha.8 h1:tRGQuDVPh66WCOelqe6LIGh0gwmfwxUrS
 github.com/mholt/archiver/v4 v4.0.0-alpha.8/go.mod h1:5f7FUYGXdJWUjESffJaYR4R60VhnHxb2X3T1teMyv5A=
 github.com/nwaples/rardecode/v2 v2.0.0-beta.2 h1:e3mzJFJs4k83GXBEiTaQ5HgSc/kOK8q0rDaRO0MPaOk=
 github.com/nwaples/rardecode/v2 v2.0.0-beta.2/go.mod h1:yntwv/HfMc/Hbvtq9I19D1n58te3h6KsqCf3GxyfBGY=
+github.com/nyudlts/go-bagit v0.3.0-alpha.0.20240515212815-8dab411c23af h1:I3StjEXH279zjQyXyBFuTyf+ga1sdySf0C2xtpHU0Ag=
+github.com/nyudlts/go-bagit v0.3.0-alpha.0.20240515212815-8dab411c23af/go.mod h1:ASz84B/bXWNXm84rt+eYAs4vUJqa2C7V/kzHSVVRxl8=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/otiai10/copy v1.14.0 h1:dCI/t1iTdYGtkvCuBG2BgR6KZa83PTclw4U5n2wAllU=
 github.com/otiai10/copy v1.14.0/go.mod h1:ECfuL02W+/FkTWZWgQqXPWZgW9oeKCSQ5qVfSc4qc4w=
@@ -168,8 +170,8 @@ github.com/ulikunitz/xz v0.5.10/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0o
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
-go.artefactual.dev/tools v0.12.0 h1:NxSnKoTcYEwnr91/8fOjC5gr20uhVlU5ouboIHAhT9M=
-go.artefactual.dev/tools v0.12.0/go.mod h1:exAc0MSKv1oXXb3FuSwkN+tg0n95HHGKpM18lxu4CKU=
+go.artefactual.dev/tools v0.14.0 h1:ESLbemsnkdIPmYXtz0uZTcPqVnTUXIEZd9DSTRyTZqY=
+go.artefactual.dev/tools v0.14.0/go.mod h1:5RJ7ObocHZv/zQFYFv/zG9cW/UVRGPFywcJx/oQ+TG8=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=


### PR DESCRIPTION
- Upgrade Go version in go.mod to 1.21.4 as required by github.com/nyudlts/go-bagit
- Add a `bagit.CreateBagActivity()` for creating BagIt bags