### PR TITLE
Re-enable loop variable capture linter warnings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -45,5 +45,3 @@ linters-settings:
     exclude-generated: false
     severity: low
     confidence: low
-    excludes:
-      - G601 # Implicit memory aliasing of items (only for Go 1.21 or lower)


### PR DESCRIPTION
These warnings are relevant again now that we've reduced the required Go version to 1.21.