### PR TITLE
Improve golangci-lint and add golines in CI lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,6 +32,32 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-golangci-lint-cache-
       - name: Run golangci-lint
-        run: make lint
+        run: |
+          make lint
+            if [ -n "$(git status --porcelain)" ]; then
+              printf "golangci-lint reported necessary changes\n"
+              git diff
+              exit 1
+            fi
         env:
           GOLANGCI_LINT_CACHE: ${{ runner.temp }}/golangci-lint-cache
+  golines:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Read Go version
+        id: go_version
+        run: echo "go_version=$(cat .go-version)" >> $GITHUB_OUTPUT
+      - name: Install Go (${{ steps.go_version.outputs.go_version }})
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ steps.go_version.outputs.go_version }}
+      - name: Run golines
+        run: |
+          make golines
+          if [ -n "$(git status --porcelain)" ]; then
+            printf "golines reported necessary changes\n"
+            git diff
+            exit 1
+          fi

--- a/bagit/validate_activity_test.go
+++ b/bagit/validate_activity_test.go
@@ -145,5 +145,9 @@ func TestValidateSystemError(t *testing.T) {
 	)
 
 	_, err := env.ExecuteActivity(bagit.ValidateActivityName, bagit.ValidateActivityParams{})
-	assert.Error(t, err, "activity error (type: validate-bag-activity, scheduledEventID: 0, startedEventID: 0, identity: ): bagit validate activity: transporter accident")
+	assert.Error(
+		t,
+		err,
+		"activity error (type: validate-bag-activity, scheduledEventID: 0, startedEventID: 0, identity: ): bagit validate activity: transporter accident",
+	)
 }

--- a/xml/xsd_validate_activity.go
+++ b/xml/xsd_validate_activity.go
@@ -47,7 +47,7 @@ func (a *XSDValidateActivity) Execute(
 	return &XSDValidateActivityResult{Failures: lintErrors}, nil
 }
 
-func checkXML(ctx context.Context, xmlFilePath string, xsdFilePath string) ([]byte, error) {
+func checkXML(ctx context.Context, xmlFilePath, xsdFilePath string) ([]byte, error) {
 	toolFilePath, err := exec.LookPath("xmllint")
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Check individual commits for more info, I separated the changes in four commits to be able to see the failures in CI. I think it's okay to merge like that but let me know if you think squashing them into one is better.