### PR TITLE
Change xmlvalidate failure result type

### DIFF
--- a/xmlvalidate/activity_test.go
+++ b/xmlvalidate/activity_test.go
@@ -57,7 +57,7 @@ func TestActivity(t *testing.T) {
 					params.XMLFilePath,
 				)
 
-				return xmlvalidate.Result{Failures: []byte(invalidXMLFailures)}
+				return xmlvalidate.Result{Failures: []string{invalidXMLFailures}}
 			},
 		},
 		{
@@ -83,7 +83,7 @@ func TestActivity(t *testing.T) {
 					params.XSDFilePath,
 				)
 
-				return xmlvalidate.Result{Failures: []byte(invalidXSDFailures)}
+				return xmlvalidate.Result{Failures: []string{invalidXSDFailures}}
 			},
 		},
 		{


### PR DESCRIPTION
Change the xmlvalidate failure results to match the other validation activity results (i.e. `Failures: []string`).