### PR TITLE
Upgrade golangci-lint from 1.56.2 to 1.61.0

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,8 +1,5 @@
 run:
   deadline: 60s
-  skip-dirs:
-    - .github
-    - hack
 
 linters:
   enable:
@@ -14,6 +11,9 @@ linters:
     - gosec
 
 issues:
+  exclude-dirs:
+    - .github
+    - hack
   exclude-rules:
     - path: _test\.go
       linters:

--- a/hack/make/dep_golangci_lint.mk
+++ b/hack/make/dep_golangci_lint.mk
@@ -5,7 +5,7 @@ $(call _assert_var,UNAME_ARCH)
 $(call _assert_var,CACHE_VERSIONS)
 $(call _assert_var,CACHE_BIN)
 
-GOLANGCI_LINT_VERSION ?= 1.56.2
+GOLANGCI_LINT_VERSION ?= 1.61.0
 
 ARCH := $(UNAME_ARCH)
 ifeq ($(UNAME_ARCH),x86_64)


### PR DESCRIPTION
Match version of golangci-lint used by enduro and other artefactual-sdps projects.