### PR TITLE
Don't re-Bag directories that are already Bags

### DIFF
--- a/bagcreate/activity.go
+++ b/bagcreate/activity.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"io/fs"
+	"os"
+	"path/filepath"
 
 	gobagit "github.com/nyudlts/go-bagit"
 	cp "github.com/otiai10/copy"
@@ -51,6 +53,11 @@ func New(cfg Config) *Activity {
 func (a *Activity) Execute(ctx context.Context, params *Params) (*Result, error) {
 	logger := temporal.GetLogger(ctx)
 	logger.V(1).Info("Executing bag-create activity", "SourcePath", params.SourcePath)
+
+	// Check if directory is already a Bag
+	if _, err := os.Stat(filepath.Join(params.SourcePath, "bagit.txt")); err == nil {
+		return &Result{BagPath: params.SourcePath}, nil
+	}
 
 	dest, err := a.create(params.SourcePath, params.BagPath)
 	if err != nil {

--- a/bagcreate/activity_test.go
+++ b/bagcreate/activity_test.go
@@ -48,6 +48,17 @@ func sourcePath(t *testing.T) string {
 	return td.Path()
 }
 
+func existingBagPath(t *testing.T) string {
+	t.Helper()
+
+	td := tfs.NewDir(t, "sdps_bagit_existing_bag_create_test",
+		tfs.WithFile("bagit.txt", "Fake bagit file\n"),
+		tfs.WithDir("data"),
+	)
+
+	return td.Path()
+}
+
 func TestActivity(t *testing.T) {
 	t.Parallel()
 
@@ -106,6 +117,16 @@ func TestActivity(t *testing.T) {
 				BagPath:    tfs.NewDir(t, "sdps_bagit_create_test", tfs.WithMode(0o600)).Path(),
 			},
 			wantErr: "activity error (type: bag-create, scheduledEventID: 0, startedEventID: 0, identity: ): bagcreate: copy source dir to bag path: open",
+		},
+		{
+			name: "Errors if source dir is already a bag",
+			params: bagcreate.Params{
+				SourcePath: existingBagPath(t),
+			},
+			want: tfs.Expected(t,
+				tfs.WithFile("bagit.txt", "Fake bagit file\n"),
+				tfs.WithDir("data"),
+			),
 		},
 	} {
 		tt := tt


### PR DESCRIPTION
Added logic in create Bag activity to not try to create Bags from directories that are already Bags.