### PR TITLE
Allow empty dir path in bucketdownload activity

### DIFF
--- a/bucketdownload/README.md
+++ b/bucketdownload/README.md
@@ -2,9 +2,11 @@
 
 Downloads a file/blob from a configured [gocloud.dev/blob] bucket. Allows
 setting the directory, filename and permissions of the downloaded file. It will
-create any missing directory if needed. If the permission parameters are not
-set, it will use `0o700` for directories and `0o600` for the file. If the
-filename is not provided, it will use the object key.
+create any missing directory if needed when the the dir path is set, otherwise
+it will create one in the default directory for temporary files. If the
+permission parameters are not set, it will use `0o700` for directories and
+`0o600` for the file. If the filename is not provided, it will use the object
+key.
 
 This activity will heartbeat each one-third of the configured timeout, if set
 in the activity options.

--- a/bucketdownload/activity.go
+++ b/bucketdownload/activity.go
@@ -15,11 +15,21 @@ const Name = "bucket-download"
 
 type (
 	Params struct {
-		DirPath  string
-		DirPerm  os.FileMode
+		// Target directory, if missing it will create a new
+		// one in the default directory for temporary files.
+		DirPath string
+
+		// Target directory permissions, default: 0o700.
+		DirPerm os.FileMode
+
+		// Target filename, if missing it will use the Key value.
 		FileName string
+
+		// Target file permissions, default: 0o600.
 		FilePerm os.FileMode
-		Key      string
+
+		// Key from the object storage.
+		Key string
 	}
 	Result struct {
 		FilePath string
@@ -37,13 +47,20 @@ func (a *Activity) Execute(ctx context.Context, params *Params) (*Result, error)
 	h := temporal.StartAutoHeartbeat(ctx)
 	defer h.Stop()
 
-	dirPerm := fs.FileMode(0o700)
-	if params.DirPerm != 0 {
-		dirPerm = params.DirPerm
-	}
-
-	if err := os.MkdirAll(params.DirPath, dirPerm); err != nil {
-		return nil, fmt.Errorf("bucketdownload: create directory: %w", err)
+	if params.DirPath != "" {
+		dirPerm := fs.FileMode(0o700)
+		if params.DirPerm != 0 {
+			dirPerm = params.DirPerm
+		}
+		if err := os.MkdirAll(params.DirPath, dirPerm); err != nil {
+			return nil, fmt.Errorf("bucketdownload: create directory: %w", err)
+		}
+	} else {
+		destDir, err := os.MkdirTemp("", "bucketdownload")
+		if err != nil {
+			return nil, fmt.Errorf("bucketdownload: create temp directory: %w", err)
+		}
+		params.DirPath = destDir
 	}
 
 	fileName := params.Key

--- a/bucketdownload/activity_test.go
+++ b/bucketdownload/activity_test.go
@@ -89,6 +89,20 @@ func TestActivity(t *testing.T) {
 			),
 		},
 		{
+			name:   "Downloads to temp directory when DirPath is empty",
+			bucket: bucket(t, "file.txt", "content"),
+			setUp: func(t *testing.T) setup {
+				return setup{
+					params: bucketdownload.Params{Key: "file.txt"},
+					// Resulting FilePath is not predictable.
+				}
+			},
+			wantFs: fs.Expected(
+				t,
+				fs.WithFile("file.txt", "content", fs.WithMode(0o600)),
+			),
+		},
+		{
 			name:   "Downloads creating file",
 			bucket: bucket(t, "file.txt", "content"),
 			setUp: func(t *testing.T) setup {
@@ -203,7 +217,16 @@ func TestActivity(t *testing.T) {
 			assert.NilError(t, err)
 
 			var result bucketdownload.Result
-			_ = enc.Get(&result)
+			err = enc.Get(&result)
+			assert.NilError(t, err)
+
+			// Missing DirPath param, one check the created temp directory contents.
+			if setup.params.DirPath == "" {
+				dir := filepath.Dir(result.FilePath)
+				assert.Assert(t, fs.Equal(dir, tt.wantFs))
+				return
+			}
+
 			assert.DeepEqual(t, result, setup.wantRes)
 			assert.Assert(t, fs.Equal(setup.params.DirPath, tt.wantFs))
 		})


### PR DESCRIPTION
If the `DirPath` parameter is missing, create a new directory in the default directory for temporary files and download the file there.

Refs https://github.com/artefactual-sdps/enduro/issues/1210.