### PR TITLE
Add disallowlist support to ffvalidate activity

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ help:
 
 fmt: # @HELP Format the project Go files with golangci-lint.
 fmt: FMT_FLAGS ?=
-fmt: tool-golangci-lint
+fmt: $(GOLANGCI_LINT)
 	golangci-lint fmt $(FMT_FLAGS)
 
 lint: # @HELP Lint the project Go files with golangci-lint (linters + formatters).

--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ the object key and the buffer size.
 ### ffvalidate
 
 Identifies the file format of the files at the given path, recursively walking
-any sub-directories, and validates that the formats are in the list of allowed
-formats.
+any sub-directories, and validates that the formats are in the configured list
+of allowed or disallowed formats.
 
 [Read more](./ffvalidate/README.md)
 

--- a/ffvalidate/README.md
+++ b/ffvalidate/README.md
@@ -1,15 +1,19 @@
 # ffvalidate
 
 Identifies the file format of the files at the given path, recursively walking
-any sub-directories, and validates that the formats are in the list of allowed
-formats.
+any sub-directories, and validates that the formats are in the configured list
+of allowed or disallowed formats.
 
 ## Requirements
 
-This activity requires reading an allowed file formats CSV file which path is
-set on the activity configuration. This file can contain multiple columns, the
-only requirement is to include a column with the `PRONOM PUID` heading (case
-insensitive) and the allowed values. A simplified example:
+This activity can read an allowed or disallowed file formats CSV file. Configure
+one of `AllowlistPath` or `DisallowlistPath`; configuring both is invalid.
+Call `Config.Validate()` before registering the activity if you want to fail
+fast instead of waiting for activity execution failures.
+
+The CSV file can contain multiple columns. The only requirement is to include a
+column with the `PRONOM PUID` heading (case insensitive) and the listed values.
+A simplified example:
 
 ```csv
 Format name,PRONOM PUID
@@ -40,6 +44,9 @@ import (
 
 tw := worker.New(...)
 cfg := ffvalidate.Config{AllowlistPath: "/path/to/allowed_file_formats.csv"}
+if err := cfg.Validate(); err != nil {
+    return err
+}
 
 tw.RegisterActivityWithOptions(
     ffvalidate.New(cfg).Execute,
@@ -74,5 +81,6 @@ err := workflow.ExecuteActivity(
 ).Get(opts, &re)
 ```
 
-`err` may contain any non validation error. `re.Failures` contains a list of
-files that are not an allowed format.
+`err` may contain any non validation error. When using `AllowlistPath`,
+`re.Failures` contains files that are not an allowed format. When using
+`DisallowlistPath`, `re.Failures` contains files that are a disallowed format.

--- a/ffvalidate/activity.go
+++ b/ffvalidate/activity.go
@@ -55,26 +55,37 @@ type formatList map[string]struct{}
 func (a *Activity) Execute(ctx context.Context, params *Params) (*Result, error) {
 	logger := temporal.GetLogger(ctx)
 
-	if a.cfg.AllowlistPath == "" {
-		logger.Info(Name + ": No allowlist path configured, skipping file format validation")
+	if err := a.cfg.Validate(); err != nil {
+		return nil, fmt.Errorf("%s: invalid config: %v", Name, err)
+	}
+
+	listPath := a.cfg.AllowlistPath
+	mode := "allowed"
+	if listPath == "" {
+		listPath = a.cfg.DisallowlistPath
+		mode = "disallowed"
+	}
+
+	if listPath == "" {
+		logger.Info(Name + ": No allowlist or disallowlist path configured, skipping file format validation")
 
 		return nil, nil
 	}
 
-	f, err := os.Open(a.cfg.AllowlistPath)
+	f, err := os.Open(listPath)
 	if err != nil {
 		return nil, fmt.Errorf("%s: %v", Name, err)
 	}
 	defer f.Close()
 
-	allowed, err := parseFormatList(f)
+	formats, err := parseFormatList(f)
 	if err != nil {
-		return nil, fmt.Errorf("%s: load allowed formats: %v", Name, err)
+		return nil, fmt.Errorf("%s: load %s formats: %v", Name, mode, err)
 	}
 
-	failures, err := checkAllowed(allowed, params.Path)
+	failures, err := checkFormats(formats, params.Path, mode)
 	if err != nil {
-		return nil, fmt.Errorf("%s: check allowed formats: %v", Name, err)
+		return nil, fmt.Errorf("%s: check %s formats: %v", Name, mode, err)
 	}
 
 	return &Result{Failures: failures}, nil
@@ -114,13 +125,13 @@ func parseFormatList(r io.Reader) (formatList, error) {
 	}
 
 	if len(formats) == 0 {
-		return nil, fmt.Errorf("no allowed file formats")
+		return nil, errors.New("no file formats found")
 	}
 
 	return formats, nil
 }
 
-func checkAllowed(allowed formatList, base string) ([]string, error) {
+func checkFormats(formats formatList, base, mode string) ([]string, error) {
 	var failures []string
 
 	sf := NewSiegfriedEmbed()
@@ -143,8 +154,15 @@ func checkAllowed(allowed formatList, base string) ([]string, error) {
 			return fmt.Errorf("get relative path: %v", err)
 		}
 
-		if _, ok := allowed[ff.ID]; !ok {
-			failures = append(failures, fmt.Sprintf("file format %q not allowed: %q", ff.ID, rel))
+		switch mode {
+		case "allowed":
+			if _, ok := formats[ff.ID]; !ok {
+				failures = append(failures, fmt.Sprintf("file format %q not allowed: %q", ff.ID, rel))
+			}
+		case "disallowed":
+			if _, ok := formats[ff.ID]; ok {
+				failures = append(failures, fmt.Sprintf("file format %q disallowed: %q", ff.ID, rel))
+			}
 		}
 
 		return nil

--- a/ffvalidate/activity_test.go
+++ b/ffvalidate/activity_test.go
@@ -57,6 +57,10 @@ fmt/95,"PDF/A "
 " x-fmt/111 ","text file"
 `)).Join("allowlist.csv")
 
+	disallowedFormatsList := fs.NewDir(t, "", fs.WithFile("disallowlist.csv", `Format,PRONOM PUID
+PNG,fmt/11
+`)).Join("disallowlist.csv")
+
 	tests := []struct {
 		name    string
 		cfg     ffvalidate.Config
@@ -68,6 +72,11 @@ fmt/95,"PDF/A "
 		{
 			name:   "Succeeds with valid formats",
 			cfg:    ffvalidate.Config{AllowlistPath: "./testdata/allowed_file_formats.csv"},
+			params: ffvalidate.Params{Path: validFormatsDir},
+		},
+		{
+			name:   "Succeeds with valid formats not in disallowlist",
+			cfg:    ffvalidate.Config{DisallowlistPath: disallowedFormatsList},
 			params: ffvalidate.Params{Path: validFormatsDir},
 		},
 		{
@@ -93,6 +102,23 @@ fmt/95,"PDF/A "
 			},
 		},
 		{
+			name:   "Fails with disallowed formats",
+			cfg:    ffvalidate.Config{DisallowlistPath: disallowedFormatsList},
+			params: ffvalidate.Params{Path: invalidFormatsDir},
+			want: ffvalidate.Result{
+				Failures: []string{
+					fmt.Sprintf(
+						`file format %q disallowed: "invalid_sip/dir/file1.png"`,
+						"fmt/11",
+					),
+					fmt.Sprintf(
+						`file format %q disallowed: "invalid_sip/file2.png"`,
+						"fmt/11",
+					),
+				},
+			},
+		},
+		{
 			name:    "Fails with empty source",
 			cfg:     ffvalidate.Config{AllowlistPath: "./testdata/allowed_file_formats.csv"},
 			params:  ffvalidate.Params{Path: fs.NewDir(t, "", fs.WithFile("file.txt", "")).Path()},
@@ -101,7 +127,16 @@ fmt/95,"PDF/A "
 		{
 			name:    "Does nothing when no allowlist path configured",
 			params:  ffvalidate.Params{Path: validFormatsDir},
-			wantLog: "INFO validate-file-formats: No allowlist path configured, skipping file format validation ActivityID 0 ActivityType validate-file-formats\n",
+			wantLog: "INFO validate-file-formats: No allowlist or disallowlist path configured, skipping file format validation ActivityID 0 ActivityType validate-file-formats\n",
+		},
+		{
+			name: "Errors when allowlist and disallowlist are both configured",
+			cfg: ffvalidate.Config{
+				AllowlistPath:    "./testdata/allowed_file_formats.csv",
+				DisallowlistPath: disallowedFormatsList,
+			},
+			params:  ffvalidate.Params{Path: validFormatsDir},
+			wantErr: "validate-file-formats: invalid config: AllowlistPath and DisallowlistPath cannot both be set",
 		},
 		{
 			name:    "Errors when allowlist path doesn't exist",
@@ -113,7 +148,7 @@ fmt/95,"PDF/A "
 			name:    "Errors when allowlist is empty",
 			cfg:     ffvalidate.Config{AllowlistPath: emptyList},
 			params:  ffvalidate.Params{Path: validFormatsDir},
-			wantErr: "validate-file-formats: load allowed formats: no allowed file formats",
+			wantErr: "validate-file-formats: load allowed formats: no file formats found",
 		},
 		{
 			name:    "Errors when no PRONOM PUID column exists",

--- a/ffvalidate/config.go
+++ b/ffvalidate/config.go
@@ -1,5 +1,20 @@
 package ffvalidate
 
+import "errors"
+
 type Config struct {
-	AllowlistPath string
+	AllowlistPath    string
+	DisallowlistPath string
+}
+
+// Validate checks for invalid configuration.
+//
+// Call Validate before registering the activity if you want configuration
+// errors to fail fast instead of waiting for activity execution failures.
+func (c Config) Validate() error {
+	if c.AllowlistPath != "" && c.DisallowlistPath != "" {
+		return errors.New("AllowlistPath and DisallowlistPath cannot both be set")
+	}
+
+	return nil
 }

--- a/ffvalidate/config_test.go
+++ b/ffvalidate/config_test.go
@@ -1,0 +1,52 @@
+package ffvalidate_test
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/artefactual-sdps/temporal-activities/ffvalidate"
+)
+
+func TestValidate(t *testing.T) {
+	t.Parallel()
+
+	type test struct {
+		name    string
+		cfg     ffvalidate.Config
+		wantErr string
+	}
+
+	for _, tt := range []test{
+		{
+			name: "No errors with allowlist path",
+			cfg:  ffvalidate.Config{AllowlistPath: "/path/to/allowlist.csv"},
+		},
+		{
+			name: "No errors with disallowlist path",
+			cfg:  ffvalidate.Config{DisallowlistPath: "/path/to/disallowlist.csv"},
+		},
+		{
+			name: "No errors with no list path",
+		},
+		{
+			name: "Errors when both list paths are configured",
+			cfg: ffvalidate.Config{
+				AllowlistPath:    "/path/to/allowlist.csv",
+				DisallowlistPath: "/path/to/disallowlist.csv",
+			},
+			wantErr: "AllowlistPath and DisallowlistPath cannot both be set",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := tt.cfg.Validate()
+			if tt.wantErr != "" {
+				assert.Error(t, err, tt.wantErr)
+				return
+			}
+			assert.NilError(t, err)
+		})
+	}
+}


### PR DESCRIPTION
Add DisallowlistPath as a mutually exclusive alternative to AllowlistPath. Validate the config during activity execution and expose Config.Validate so callers can fail fast during registration.

Refs #61.